### PR TITLE
fix url for boostrapping guide

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -5,7 +5,7 @@
 :forked_source_www: https://vsoch.github.io
 :theme_demo_www: https://asciidocsy.netlify.app
 :theme_docs_www: https://asciidocsy.netlify.app/docs
-:theme_docs_bootstrapping_www: https://asciidocsy.netlify.app/docs/theme/setup/bootstrap
+:theme_docs-bootstrapping_www: {theme_docs_www}/theme/setup/bootstrap
 :theme_repo_www: https://github.com/DocOps/asciidocsy-jekyll-theme
 :theme_repo_git: git@github.com:DocOps/asciidocsy-jekyll-theme.git
 :project_issues_path: https://github.com/DocOps/asciidocsy-jekyll-theme/issues

--- a/README.adoc
+++ b/README.adoc
@@ -206,7 +206,7 @@ You will find the generated files at `_site/`.
 // end::quickstart-build[]
 
 [TIP]
-Learn more about applying AsciiDocsy to your use case in the link:{theme_docs_bootstrapping_www}[Bootstrapping guide].
+Learn more about applying AsciiDocsy to your use case in the link:{theme_docs-bootstrapping_www}[Bootstrapping guide].
 
 == Production Environment Details
 

--- a/README.adoc
+++ b/README.adoc
@@ -5,6 +5,7 @@
 :forked_source_www: https://vsoch.github.io
 :theme_demo_www: https://asciidocsy.netlify.app
 :theme_docs_www: https://asciidocsy.netlify.app/docs
+:theme_docs_bootstrapping_www: https://asciidocsy.netlify.app/docs/theme/setup/bootstrap
 :theme_repo_www: https://github.com/DocOps/asciidocsy-jekyll-theme
 :theme_repo_git: git@github.com:DocOps/asciidocsy-jekyll-theme.git
 :project_issues_path: https://github.com/DocOps/asciidocsy-jekyll-theme/issues
@@ -205,7 +206,7 @@ You will find the generated files at `_site/`.
 // end::quickstart-build[]
 
 [TIP]
-Learn more about applying AsciiDocsy to your use case in the link:{theme_docs_www}[Bootstrapping guide].
+Learn more about applying AsciiDocsy to your use case in the link:{theme_docs_bootstrapping_www}[Bootstrapping guide].
 
 == Production Environment Details
 


### PR DESCRIPTION
Updates link in note in README to direct to bootstrapping guide in documentation