### PR TITLE
Enable labels & icons in button-formatted version handlers

### DIFF
--- a/_includes/version-handler.html
+++ b/_includes/version-handler.html
@@ -16,6 +16,7 @@ Optional:
   include.href: Liquid; For URL-based changers, non-variable portion of URL
   include.args: Object; a way to pass an object to your function template
   include.icon: String; FontAwesome reference
+  include.text: String; label for form field
 {% endcomment %}
 {% assign handler = handler | default: 0 | plus: 1 %}
 {% assign verb = include.verb %}
@@ -59,7 +60,17 @@ Optional:
 </div>
 
   {% when "buttons" %}
-<div class="btn-group btn-group-toggle {{verb}}-handler" id="{{form_id}}" name="{{form_id}}" data-toggle="buttons">
+  {% if include.text or include.icon %}
+  <label for="{{ form_id }}">
+    {% if include.icon %}
+      <i class="{{ include.icon }}"></i>
+    {% endif %}
+    {% if include.text %}
+      {{ include.text | asciidocify:'inline' }}
+    {% endif %}
+  </label>
+  {% endif %}
+<div class="btn-group btn-group-toggle {{verb}}-handler" id="{{form_id}}" data-toggle="buttons">
   {% for item in include.opts %}
     {% if item['text'] %}
       {% assign text = item['text'] %}

--- a/css/asciidocsy.css
+++ b/css/asciidocsy.css
@@ -223,6 +223,10 @@ ul.list-unstyled {
   padding-top: 80px;
 }
 
+#sidebar-right label {
+  margin-top: .5em;
+}
+
 #subject-menu {
   margin-top: 70px;
 }


### PR DESCRIPTION
This PR does not add icons to tabber tab labels, but it does add labels and icons to button-formatted version handlers.